### PR TITLE
bugfix: don't compute Feret's diameter and perimeter if not requested

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = napari-simpleitk-image-processing
-version = 0.4.1
+version = 0.4.2
 author = Robert Haase
 author_email = robert.haase@tu-dresden.de
 url = https://github.com/haesleinhuepf/napari-simpleitk-image-processing

--- a/src/napari_simpleitk_image_processing/__init__.py
+++ b/src/napari_simpleitk_image_processing/__init__.py
@@ -1,5 +1,5 @@
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"
 __common_alias__ = "nsitk"
 
 

--- a/src/napari_simpleitk_image_processing/_simpleitk_image_processing.py
+++ b/src/napari_simpleitk_image_processing/_simpleitk_image_processing.py
@@ -840,9 +840,9 @@ def label_statistics(
         intensity_stats.Execute(sitk_intensity_image, sitk_label_image)
 
     shape_stats = sitk.LabelShapeStatisticsImageFilter()
-    shape_stats.SetComputeFeretDiameter(True)
+    shape_stats.SetComputeFeretDiameter(shape)
     shape_stats.SetComputeOrientedBoundingBox(False)
-    shape_stats.SetComputePerimeter(True)
+    shape_stats.SetComputePerimeter(perimeter)
     shape_stats.Execute(sitk_label_image)
 
     results = {}


### PR DESCRIPTION
This makes computation in `label_statistics()` faster, especially if the user set `shape=False` and/or `perimeter=False`. This might solve #13 