### PR TITLE
Cast binary images to uint8 before masking to suppress deprecation warning

### DIFF
--- a/src/napari_simpleitk_image_processing/_simpleitk_image_processing.py
+++ b/src/napari_simpleitk_image_processing/_simpleitk_image_processing.py
@@ -513,7 +513,7 @@ def touching_objects_labeling(binary_image:"napari.types.LabelsData") -> "napari
                                                 useImageSpacing=False)
 
     ws = sitk.MorphologicalWatershed(distance_map, markWatershedLine=False, level=1)
-    labels = sitk.Mask(ws, sitk.Cast(binary_image, ws.GetPixelID()))
+    labels = sitk.Mask(ws, sitk.Cast(binary_image, sitk.sitkUInt8))
     return labels
 
 
@@ -543,7 +543,7 @@ def watershed_otsu_labeling(image:"napari.types.ImageData", spot_sigma: float = 
     binary_otsu = sitk.OtsuThreshold(blurred_outline, 0, 1)
 
     ws = sitk.MorphologicalWatershed(blurred_spots, markWatershedLine=False, level=watershed_level)
-    labels = sitk.Mask(ws, sitk.Cast(binary_otsu, ws.GetPixelID()))
+    labels = sitk.Mask(ws, sitk.Cast(binary_otsu, sitk.sitkUInt8))
 
     return labels
 


### PR DESCRIPTION
Hi @haesleinhuepf,

this tiny PR fixes a deprecation warning thrown by `sitk.Mask` in `touching_objects_labeling` and `watershed_otsu_labeling`. 

Specifically, the warning is:
`MaskImageFilter (0x16fcfeab0): Support for pixel type 32-bit unsigned integer for the MaskImage input has been deprecated and will be removed in future versions. Implicitly casting input to support 'sitkUInt8' type.`

Since SimpleITK casts implicitly to uint8 anyways, I changed the existing cast to uint8. Since, the masking is only applied to binarised images anyways, this should not change behaviour other than suppressing the warning. 

Have a nice day!
Jonas