### PR TITLE
Add compatibility with the 'pyclesperanto._pyclesperanto._Array' type in the if-else block.

### DIFF
--- a/src/napari_simpleitk_image_processing/_simpleitk_image_processing.py
+++ b/src/napari_simpleitk_image_processing/_simpleitk_image_processing.py
@@ -36,7 +36,8 @@ def plugin_function(
             if isinstance(value, np.ndarray):
                 np_value = value
             elif 'pyclesperanto_prototype._tier0._pycl.OCLArray' in str(type(value)) or \
-                'dask.array.core.Array' in str(type(value)):
+                'dask.array.core.Array' in str(type(value)) or \
+                'pyclesperanto._pyclesperanto._Array' in str(type(value)):
                 # compatibility with pyclesperanto and dask
                 np_value = np.asarray(value)
 


### PR DESCRIPTION
<sup>This message was generated by [git-bob](https://github.com/haesleinhuepf/git-bob) (version: 0.2.8, model: gpt-4o-2024-08-06), an experimental AI-based assistant. It can make mistakes and has [limitations](https://github.com/haesleinhuepf/git-bob?tab=readme-ov-file#limitations). Check its messages carefully.</sup>

The change made in the file `_simpleitk_image_processing.py` adds compatibility with the pyclesperanto library by including the type 'pyclesperanto._pyclesperanto._Array' to an existing if-else block. This update allows the function to handle arrays of this specific type by converting them to NumPy arrays, ensuring smooth integration and functionality with the pyclesperanto library in addition to the previously supported dask and pyclesperanto_prototype array types.

closes #26